### PR TITLE
Filter reports shown on the index page

### DIFF
--- a/ckanext/report/logic/action/get.py
+++ b/ckanext/report/logic/action/get.py
@@ -15,6 +15,10 @@ def report_list(context=None, data_dict=None):
 
     registry = ReportRegistry.instance()
     reports = registry.get_reports()
+
+    user = context['auth_user_obj']
+    reports = filter(lambda r: r.is_visible_to_user(user), reports)
+
     return [report.as_dict() for report in reports]
 
 

--- a/ckanext/report/report_registry.py
+++ b/ckanext/report/report_registry.py
@@ -153,6 +153,12 @@ class Report(object):
                 'option_defaults': self.option_defaults,
                 'template': self.get_template()}
 
+    def is_visible_to_user(self, user):
+        if hasattr(self, 'authorize'):
+            return self.authorize(user, self.option_defaults)
+        else:
+            return True
+
 
 def extract_entity_name(option_dict):
     '''Hunts for an option key that is the entity name and returns its


### PR DESCRIPTION
Only show them if the user is authorized to see the report with default
options.