### PR TITLE
OrderedDict is in ckan.common instead of helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ class TaglessReportPlugin(p.SingletonPlugin):
 The last line refers to `tag_report_info` which is a dictionary with properties of the report. This is stored in `reports.py` together with the report code (see above). The info dict looks like this:
 
 ```python
-from ckan.lib.helpers import OrderedDict
+from ckan.common import OrderedDict
 tagless_report_info = {
     'name': 'tagless-datasets',
     'description': 'Datasets which have no tags.',

--- a/ckanext/report/model.py
+++ b/ckanext/report/model.py
@@ -8,7 +8,7 @@ from sqlalchemy import types, Table, Column, Index, MetaData
 from sqlalchemy.orm import mapper
 
 from ckan import model
-from ckan.lib.helpers import OrderedDict
+from ckan.common import OrderedDict
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/report/reports.py
+++ b/ckanext/report/reports.py
@@ -3,7 +3,7 @@ Working examples - simple tag report.
 '''
 
 from ckan import model
-from ckan.lib.helpers import OrderedDict
+from ckan.common import OrderedDict
 from ckanext.report import lib
 
 


### PR DESCRIPTION
CKAN 2.6 fails while importing OrderedDict from helpers.